### PR TITLE
Catch exceptions thrown during context disposal

### DIFF
--- a/NWebDav.Server/Dispatching/BaseDispatcher.cs
+++ b/NWebDav.Server/Dispatching/BaseDispatcher.cs
@@ -127,7 +127,8 @@ namespace NWebDav.Server.Dispatching
                 }
                 catch (Exception)
                 {
-                    // Closing the context can sometimes fail, for example when MiniRedir cancels a file upload due to it being too large.
+                    // Closing the context can sometimes fail, for example when Microsoft-WebDAV-MiniRedir cancels
+                    // a PUT request due to the file size being too large.
                 }
             }
         }

--- a/NWebDav.Server/Dispatching/BaseDispatcher.cs
+++ b/NWebDav.Server/Dispatching/BaseDispatcher.cs
@@ -120,8 +120,15 @@ namespace NWebDav.Server.Dispatching
             }
             finally
             {
-                // Always close the context
-                await context.DisposeAsync().ConfigureAwait(false);
+                try
+                {
+                    // Always close the context
+                    await context.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    // Closing the context can sometimes fail, for example when MiniRedir cancels a file upload due to it being too large.
+                }
             }
         }
 


### PR DESCRIPTION
Fixed an issue where the server would stop responding to requests after a PUT request had been cancelled by Microsoft-WebDAV-MiniRedir due to the file size being too large.